### PR TITLE
jQuery3 compat : Change load event handling

### DIFF
--- a/src/javascripts/jquery.tocify.js
+++ b/src/javascripts/jquery.tocify.js
@@ -176,7 +176,7 @@
             self._setEventHandlers();
 
             // Binding to the Window load event to make sure the correct scrollTop is calculated
-            $(window).load(function() {
+            $(window).on('load',function() {
 
                 // Sets the active TOC item
                 self._setActiveElement(true);


### PR DESCRIPTION
See this breaking change : https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed